### PR TITLE
Fix issue with wrong post author

### DIFF
--- a/blocks/post-grid/class-posts-grid-block.php
+++ b/blocks/post-grid/class-posts-grid-block.php
@@ -146,9 +146,10 @@ class Posts_Grid_Block extends Base_Block {
 
 				if ( ( isset( $attributes['displayAuthor'] ) && $attributes['displayAuthor'] ) ) {
 					$list_items_markup .= sprintf(
-						'%1$s %2$s',
+						'%1$s <a href="%2$s">%3$s</a>',
 						__( 'by', 'textdomain' ),
-						get_the_author_posts_link( get_the_author_meta( $id ) )
+						get_author_posts_url( get_post_field( 'post_author', $id ) ),
+						get_the_author_meta( 'display_name', get_post_field( 'post_author', $id ) )
 					);
 				}
 

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
 	"name": "codeinwp/gutenberg-blocks",
 	"description": "A set of awesome Gutenberg Blocks!",
 	"type": "library",
-	"version": "1.0.2",
+	"version": "1.0.3",
 	"license": "GPL-2.0-or-later",
 	"homepage": "https://github.com/Codeinwp/gutenberg-blocks",
 	"authors": [

--- a/load.php
+++ b/load.php
@@ -8,7 +8,7 @@
  * @since       1.0.0
  */
 
-define( 'THEMEISLE_GUTENBERG_BLOCKS_VERSION', '1.0.2' );
+define( 'THEMEISLE_GUTENBERG_BLOCKS_VERSION', '1.0.3' );
 define( 'THEMEISLE_GUTENBERG_BLOCKS_DEV', false );
 
 add_action(

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "themeisle-gutenberg-blocks",
-	"version": "1.0.2",
+	"version": "1.0.3",
 	"description": "ThemeIsle Gutenberg Blocks",
 	"scripts": {
 		"build": "cross-env BABEL_ENV=default NODE_ENV=production webpack",


### PR DESCRIPTION
Posts Grid block was displaying wrong post author, which was fixed as well as a version bump. Fixes https://github.com/Codeinwp/gutenberg-blocks/issues/10