### PR TITLE
fix css regeneration when action is triggered by a non-logged in user

### DIFF
--- a/inc/css/class-css-handler.php
+++ b/inc/css/class-css-handler.php
@@ -29,7 +29,7 @@ class CSS_Handler extends Base_CSS {
 	public function init() {
 		add_action( 'rest_api_init', array( $this, 'register_routes' ) );
 		add_action( 'rest_api_init', array( $this, 'autoload_block_classes' ) );
-		add_action( 'before_delete_post', array( $this, 'delete_css_file' ) );
+		add_action( 'before_delete_post', array( __CLASS__, 'delete_css_file' ) );
 	}
 
 	/**
@@ -99,30 +99,58 @@ class CSS_Handler extends Base_CSS {
 		}
 
 		$post_id = $request->get_param( 'id' );
-		$css     = $this->get_blocks_css( $post_id );
-		$css     = wp_filter_nohtml_kses( $css );
-
-		if ( ! empty( $css ) ) {
-			$css = $this->compress( $css );
-
-			update_post_meta( $post_id, '_themeisle_gutenberg_block_styles', $css );
-			$this->save_css_file( $post_id, $css );
-		} else {
-			if ( get_post_meta( $post_id, '_themeisle_gutenberg_block_styles', true ) ) {
-				delete_post_meta( $post_id, '_themeisle_gutenberg_block_styles' );
-				$this->delete_css_file( $post_id );
-			}
-		}
-
-		if ( count( self::$google_fonts ) > 0 ) {
-			update_post_meta( $post_id, '_themeisle_gutenberg_block_fonts', self::$google_fonts );
-		} else {
-			if ( get_post_meta( $post_id, '_themeisle_gutenberg_block_fonts', true ) ) {
-				delete_post_meta( $post_id, '_themeisle_gutenberg_block_fonts' );
-			}
-		}
+		self::generate_css_file( $post_id );
 
 		return rest_ensure_response( array( 'message' => __( 'CSS updated.', 'textdomain' ) ) );
+	}
+
+	/**
+	 * Generate CSS file.
+	 *
+	 * @param int $post_id Post id.
+	 */
+	public static function generate_css_file( $post_id ) {
+		$css = self::instance()->get_blocks_css( $post_id );
+		self::save_css_file( $post_id, $css );
+	}
+
+	/**
+	 * Get CSS url for post.
+	 *
+	 * @param int $post_id Post id.
+	 *
+	 * @return string File url.
+	 */
+	public static function get_css_url( $post_id ) {
+		$file_name = get_post_meta( $post_id, '_themeisle_gutenberg_block_stylesheet', true );
+		if ( empty( $file_name ) ) {
+			return false;
+		}
+
+		$wp_upload_dir = wp_upload_dir( null, false );
+		$baseurl       = $wp_upload_dir['baseurl'] . '/themeisle-gutenberg/';
+
+		return $baseurl . $file_name . '.css';
+	}
+
+	/**
+	 * Check if we have a CSS file for this post.
+	 *
+	 * @param int $post_id Post ID.
+	 *
+	 * @return bool
+	 */
+	public static function has_css_file( $post_id ) {
+		$file_name = get_post_meta( $post_id, '_themeisle_gutenberg_block_stylesheet', true );
+
+		if ( empty( $file_name ) ) {
+			return false;
+		}
+		$wp_upload_dir = wp_upload_dir( null, false );
+		$basedir       = $wp_upload_dir['basedir'] . '/themeisle-gutenberg/';
+		$file_path     = $basedir . $file_name . '.css';
+
+		return is_file( $file_path );
 	}
 
 	/**
@@ -141,30 +169,12 @@ class CSS_Handler extends Base_CSS {
 
 		$post_id = $request->get_param( 'id' );
 		$css     = $this->get_reusable_block_css( $post_id );
-		$css     = wp_filter_nohtml_kses( $css );
 
-		if ( ! empty( $css ) ) {
-			$css = $this->compress( $css );
-
-			update_post_meta( $post_id, '_themeisle_gutenberg_block_styles', $css );
-			$this->save_css_file( $post_id, $css );
-		} else {
-			if ( get_post_meta( $post_id, '_themeisle_gutenberg_block_styles', true ) ) {
-				delete_post_meta( $post_id, '_themeisle_gutenberg_block_styles' );
-				$this->delete_css_file( $post_id );
-			}
-		}
-
-		if ( count( self::$google_fonts ) > 0 ) {
-			update_post_meta( $post_id, '_themeisle_gutenberg_block_fonts', self::$google_fonts );
-		} else {
-			if ( get_post_meta( $post_id, '_themeisle_gutenberg_block_fonts', true ) ) {
-				delete_post_meta( $post_id, '_themeisle_gutenberg_block_fonts' );
-			}
-		}
+		self::save_css_file( $post_id, $css );
 
 		return rest_ensure_response( array( 'message' => __( 'CSS updated.', 'textdomain' ) ) );
 	}
+
 
 	/**
 	 * Function to save CSS into WordPress Filesystem.
@@ -176,13 +186,8 @@ class CSS_Handler extends Base_CSS {
 	 * @since   1.3.0
 	 * @access  public
 	 */
-	public function save_css_file( $post_id, $css ) {
+	public static function save_css_file( $post_id, $css ) {
 		global $wp_filesystem;
-
-		if ( ! current_user_can( 'edit_posts' ) ) {
-			return false;
-		}
-
 		require_once ABSPATH . '/wp-admin/includes/file.php';
 		WP_Filesystem();
 
@@ -190,10 +195,28 @@ class CSS_Handler extends Base_CSS {
 		$wp_upload_dir = wp_upload_dir( null, false );
 		$upload_dir    = $wp_upload_dir['basedir'] . '/themeisle-gutenberg/';
 		$file_path     = $upload_dir . $file_name . '.css';
-		$target_dir    = $wp_filesystem->is_dir( $upload_dir );
+
+		$css = wp_filter_nohtml_kses( $css );
+
+		$css = self::compress( $css );
+		update_post_meta( $post_id, '_themeisle_gutenberg_block_styles', $css );
+		if ( is_file( $file_path ) ) {
+			self::delete_css_file( $post_id );
+		}
+
+		if ( count( self::$google_fonts ) > 0 ) {
+			update_post_meta( $post_id, '_themeisle_gutenberg_block_fonts', self::$google_fonts );
+		} else {
+			if ( get_post_meta( $post_id, '_themeisle_gutenberg_block_fonts', true ) ) {
+				delete_post_meta( $post_id, '_themeisle_gutenberg_block_fonts' );
+			}
+		}
+
+
+		$target_dir = $wp_filesystem->is_dir( $upload_dir );
 
 		if ( ! $wp_filesystem->is_writable( $wp_upload_dir['basedir'] ) ) {
-			return;
+			return false;
 		}
 
 		if ( ! $target_dir ) {
@@ -213,11 +236,12 @@ class CSS_Handler extends Base_CSS {
 	 * Function to delete CSS from WordPress Filesystem.
 	 *
 	 * @param int $post_id Post id.
+	 *
 	 * @return bool
 	 * @since   1.3.0
 	 * @access  public
 	 */
-	public function delete_css_file( $post_id ) {
+	public static function delete_css_file( $post_id ) {
 		global $wp_filesystem;
 
 		if ( ! current_user_can( 'edit_posts' ) ) {
@@ -255,11 +279,12 @@ class CSS_Handler extends Base_CSS {
 	 * Compress CSS
 	 *
 	 * @param string $css Compress css.
+	 *
 	 * @return string Compressed css.
 	 * @since   1.3.0
 	 * @access  public
 	 */
-	public function compress( $css ) {
+	public static function compress( $css ) {
 		$compressor = new CSSmin();
 
 		// Override any PHP configuration options before calling run().


### PR DESCRIPTION
There is an issue with the CSS generation mechanism when the generation is triggered by a non-logged in user. 

How to replicate: 

1. Regenerate the CSS style using Otter's regenerate CSS's method. 
2. Open an incognito browser and check a page that should have a CSS style generated by Otter.
3. Because the save_css_file method is allowing the CSS generation only for logged in users, the CSS fails to be generated. 



