### PR TITLE
Fix the post excerpt become corrupted when containing multi-byte characters

### DIFF
--- a/inc/render/class-posts-grid-block.php
+++ b/inc/render/class-posts-grid-block.php
@@ -292,8 +292,8 @@ class Posts_Grid_Block extends Base_Block {
 	protected function get_excerpt_by_id( $post_id, $excerpt_length = 200 ) {
 		$excerpt = get_the_excerpt( $post_id );
 
-		if ( strlen( $excerpt ) > $excerpt_length ) {
-			$excerpt = substr( $excerpt, 0, $excerpt_length ) . '…';
+		if ( mb_strlen( $excerpt ) > $excerpt_length ) {
+			$excerpt = mb_substr( $excerpt, 0, $excerpt_length ) . '…';
 		}
 
 		return $excerpt;


### PR DESCRIPTION
The post excerpt may become corrupted when the post content contains multi-byte characters, such as Chinese.
<img width="717" alt="116342707-ab7fef80-a815-11eb-8084-ed75e44ad238" src="https://user-images.githubusercontent.com/6083887/116953503-0014e600-acc0-11eb-9b4b-631325fb115a.png">
