### PR TITLE
Save CSS to Otter CSS File

### DIFF
--- a/inc/class-base-css.php
+++ b/inc/class-base-css.php
@@ -331,6 +331,8 @@ class Base_CSS {
 				}
 			}
 
+			$style .= apply_filters( 'themeisle_gutenberg_blocks_css', $block );
+
 			if ( isset( $block['innerBlocks'] ) && ! empty( $block['innerBlocks'] ) && is_array( $block['innerBlocks'] ) ) {
 				$style .= $this->cycle_through_static_blocks( $block['innerBlocks'] );
 			}

--- a/inc/css/class-block-frontend.php
+++ b/inc/css/class-block-frontend.php
@@ -38,6 +38,13 @@ class Block_Frontend extends Base_CSS {
 	private $has_fonts = true;
 
 	/**
+	 * Inline CSS size.
+	 *
+	 * @var int
+	 */
+	private $total_inline_size = 0;
+
+	/**
 	 * Initialize the class
 	 */
 	public function init() {
@@ -265,6 +272,26 @@ class Block_Frontend extends Base_CSS {
 
 		if ( is_array( $blocks ) || ! empty( $blocks ) ) {
 			$this->enqueue_reusable_styles( $blocks, $footer );
+		}
+
+		$total_inline_limit = 20000;
+		$total_inline_limit = apply_filters( 'styles_inline_size_limit', 20000 );
+
+		$wp_upload_dir = wp_upload_dir( null, false );
+		$basedir       = $wp_upload_dir['basedir'] . '/themeisle-gutenberg/';
+		$file_path     = $basedir . $file_name;
+		$file_size     = filesize( $file_path );
+
+		if ( $this->total_inline_size + $file_size < $total_inline_limit ) {
+			add_action(
+				$location,
+				function () use ( $post_id ) {
+					return $this->get_post_css( $post_id );
+				}
+			);
+
+			$this->total_inline_size += (int) $file_size;
+			return;
 		}
 
 		if ( $footer ) {

--- a/inc/css/class-css-handler.php
+++ b/inc/css/class-css-handler.php
@@ -230,7 +230,7 @@ class CSS_Handler extends Base_CSS {
 		require_once ABSPATH . '/wp-admin/includes/file.php';
 		WP_Filesystem();
 
-		$file_name     = 'post-' . $post_id . '-' . time();
+		$file_name     = 'post-v2-' . $post_id . '-' . time();
 		$wp_upload_dir = wp_upload_dir( null, false );
 		$upload_dir    = $wp_upload_dir['basedir'] . '/themeisle-gutenberg/';
 		$file_path     = $upload_dir . $file_name . '.css';


### PR DESCRIPTION
We try to save CSS to Otter's CSS file if it exists. Part of https://github.com/Codeinwp/gutenberg-blocks/issues/785

One also needs to use this PR for this to work: https://github.com/Codeinwp/gutenberg-css/pull/307

Things to make sure:

- Custom CSS is saved to Otter's CSS files.
- For older posts made before this version, custom CSS should appear to display properly.
- If either plugin is not installed then there shouldn't be any bugs.
- We also don't load CSS file up to 20kbs and load it inline. Only if the CSS gets past that limit, we load the CSS file.