### PR TITLE
Remove default value for `font-family` in Adv Heading

### DIFF
--- a/src/blocks/advanced-heading/edit.js
+++ b/src/blocks/advanced-heading/edit.js
@@ -179,7 +179,7 @@ const Edit = ({
 	const style = {
 		color: attributes.headingColor,
 		...fontSizeStyle,
-		fontFamily: attributes.fontFamily ? attributes.fontFamily : 'inherit',
+		fontFamily: attributes.fontFamily,
 		fontWeight: 'regular' === attributes.fontVariant ? 'normal' : attributes.fontVariant,
 		fontStyle: attributes.fontStyle,
 		textTransform: attributes.textTransform,


### PR DESCRIPTION
Fix #799

For an easy merging, no build provided.